### PR TITLE
fix shellcheck issues in extract() and env.sh

### DIFF
--- a/dotfiles/sh/env.sh
+++ b/dotfiles/sh/env.sh
@@ -49,7 +49,7 @@ paths=(
   "$HOME/.bin" "$HOME/bin"                                # personal executables
 )
 
-for p in ${paths[@]}; do
+for p in "${paths[@]}"; do
   if [[ -d "$p" ]]; then
     case ":$PATH:" in
       *":$p:") ;;
@@ -66,7 +66,7 @@ manpaths=(
 )
 
 mp=""
-for p in ${manpaths[@]}; do
+for p in "${manpaths[@]}"; do
   [[ -d "$p" ]] && mp="${mp:+$mp:}$p"
 done
 

--- a/dotfiles/sh/functions/archive.sh
+++ b/dotfiles/sh/functions/archive.sh
@@ -47,18 +47,18 @@ Extract various archive formats including zip, tar, 7z, rar, etc."
   [ ! -f "$1" ] && echo "'$1' is not a valid file" && return 1
 
   case $1 in
+    *.tar.bz2|*.tbz2)  command tar -jxvf "$1" ;;
+    *.tar.gz|*.tgz)    if command -v unpigz >/dev/null 2>&1; then command tar --use-compress-program=unpigz -xvf "$1"; else command tar -zxvf "$1"; fi ;;
+    *.tar.lz|*.tlz)    command tar --lzip -xvf "$1" ;;
+    *.tar.xz|*.txz)    command tar -Jxvf "$1" ;;
+    *.tar.zst)         command tar --zstd -xvf "$1" ;;
+    *.tar)             command tar -xvf "$1" ;;
     *.7z)              command 7za x "$1"   ;;
     *.bz2)             command bunzip2 "$1"  ;;
     *.dmg)             hdiutil mount "$1" ;;
     *.gz)              if command -v unpigz >/dev/null 2>&1; then command unpigz "$1"; else command gunzip "$1"; fi ;;
     *.lz)              command lzip -d "$1" ;;
     *.rar)             command unrar x "$1" ;;
-    *.tar)             command tar -xvf "$1" ;;
-    *.tar.bz2|*.tbz2)  command tar -jxvf "$1" ;;
-    *.tar.gz|*.tgz)    if command -v unpigz >/dev/null 2>&1; then command tar --use-compress-program=unpigz -xvf "$1"; else command tar -zxvf "$1"; fi ;;
-    *.tar.lz|*.tlz)    command tar --lzip -xvf "$1" ;;
-    *.tar.xz|*.txz)    command tar -Jxvf "$1" ;;
-    *.tar.zst)         command tar --zstd -xvf "$1" ;;
     *.xz)              command unxz "$1" ;;
     *.zst)             command zstd -d "$1" ;;
     *.Z)               command uncompress "$1" ;;


### PR DESCRIPTION
## Summary
- **extract() case pattern ordering**: `*.bz2` matched before `*.tar.bz2` (same for `.gz` and `.lz`), so `extract foo.tar.bz2` would run `bunzip2` instead of `tar -jxvf`. Moved compound extensions before simple ones.
- **Unquoted array expansions in env.sh**: `${paths[@]}` and `${manpaths[@]}` were not quoted, causing word splitting if any path contained spaces.

## Test plan
- [ ] Run `extract` against a `.tar.gz` and `.tar.bz2` file and verify correct extraction
- [ ] Source `env.sh` on both macOS and Linux and verify PATH is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)