### PR TITLE
Add DietPi directories to PATH

### DIFF
--- a/sh/aliases.sh
+++ b/sh/aliases.sh
@@ -120,6 +120,17 @@ alias sudo='sudo '
 # generate a random number
 alias rand='od -An -N2 -i /dev/urandom | xargs'
 
+# DietPi
+if [[ -d '/boot/dietpi' ]]; then
+  for cmd in /boot/dietpi/dietpi-*; do
+    alias "$(basename "$cmd")"="$cmd"
+  done
+  for cmd in /boot/dietpi/func/dietpi-* /boot/dietpi/misc/dietpi-*; do
+    [[ -x "$cmd" ]] && alias "$(basename "$cmd")"="$cmd"
+  done
+  alias cpu='/boot/dietpi/dietpi-cpuinfo'
+fi
+
 # macOS
 if [[ "$(uname -s)" == "Darwin" ]]; then
   # brew

--- a/sh/env.sh
+++ b/sh/env.sh
@@ -44,6 +44,7 @@ paths=(
   "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"            # android cmdline-tools
   /opt/homebrew/opt/coreutils/libexec/gnubin              # homebrew GNU utilities (arm64)
   /opt/homebrew/bin /opt/homebrew/sbin                    # homebrew (arm64)
+  /boot/dietpi /boot/dietpi/func /boot/dietpi/misc        # DietPi
   "$HOME/.local/bin"                                      # user-specific executable files
   "$HOME/.bin" "$HOME/bin"                                # personal executables
 )

--- a/sh/env.sh
+++ b/sh/env.sh
@@ -44,7 +44,6 @@ paths=(
   "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"            # android cmdline-tools
   /opt/homebrew/opt/coreutils/libexec/gnubin              # homebrew GNU utilities (arm64)
   /opt/homebrew/bin /opt/homebrew/sbin                    # homebrew (arm64)
-  /boot/dietpi /boot/dietpi/func /boot/dietpi/misc        # DietPi
   "$HOME/.local/bin"                                      # user-specific executable files
   "$HOME/.bin" "$HOME/bin"                                # personal executables
 )


### PR DESCRIPTION
Add /boot/dietpi, /boot/dietpi/func, and /boot/dietpi/misc to PATH on DietPi systems so dietpi-* commands work from zsh.

DietPi normally sets these up as [bash aliases](https://github.com/MichaIng/DietPi/blob/master/rootfs/etc/bashrc.d/dietpi.bash) which don't load in zsh. Adding the directories to PATH is a simpler, shell-agnostic fix.