### PR TITLE
fix stale files left by private asset install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,16 @@ private:
 			echo "Private assets up to date ($$latest)"; \
 		else \
 			echo "Installing private assets $$latest..."; \
-			mkdir -p $(PRIVATE_DIR); \
+			tmp=$$(mktemp -d); \
 			gh release download "$$latest" --repo $(PRIVATE_REPO) \
 				--pattern 'dotfiles-private-*.tar.gz' \
-				--dir $(PRIVATE_DIR) --clobber; \
-			tar xzf $(PRIVATE_DIR)/dotfiles-private-*.tar.gz \
+				--dir "$$tmp" --clobber; \
+			rm -rf $(PRIVATE_DIR); \
+			mkdir -p $(PRIVATE_DIR); \
+			tar xzf "$$tmp"/dotfiles-private-*.tar.gz \
 				-C $(PRIVATE_DIR) --strip-components=1; \
+			rm -rf "$$tmp"; \
 			$(PRIVATE_DIR)/install.sh; \
-			rm -f $(PRIVATE_DIR)/dotfiles-private-*.tar.gz; \
 			echo "$$latest" > $(PRIVATE_DIR)/.version; \
 		fi; \
 	fi


### PR DESCRIPTION
## Problem
`make private` extracts the release tarball straight over `private/` with `tar x --strip-components=1`. `tar` overwrites files present in the archive but never removes files that a newer release dropped, so stale assets linger.

Live example in `private/fonts`: v3 MonoLisa files are dated Jul 3, but v2-only weight variants (`MonoLisaNerdFontMono-LightItalic.ttf`, `-MediumRegular.ttf`, `-SemiBold*`, etc.) are still present from Apr 1.

## Fix
Download the tarball into a temp dir, `rm -rf` + recreate `private/` for a clean slate, then extract. `private/` is fully gitignored and entirely release-managed, so wiping is safe. Also drops the now-redundant tarball-cleanup line.

Verified by simulation: old flow keeps a dropped file alongside new ones; new flow leaves only the new set.